### PR TITLE
Add install_requires to make sure html5lib is installed automatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     download_url='https://github.com/danthedeckie/html5validate/tarball/' + __version__,
     keywords = ['html5', 'validation', 'web', 'lint'],
     test_suite='tests',
+    install_requires=["html5lib"],
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Developers',
                  'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
This line adds html5lib as a dependency, which means it will be installed if it isn't already. I tried installing the lib, but was surprised that it crashed with an import error when ran with a basic example.